### PR TITLE
edited get_data to output updates to csvs

### DIFF
--- a/get_data.R
+++ b/get_data.R
@@ -1,12 +1,17 @@
 
-
+library(purrr)
+library(rvest)
+library(rlang)
 
 #check current version
 league
 
 #update leage streams
 league <- update_streams(league)
-
-#save output to an RDS file
-saveRDS(league, file = "league_jun_1.rds")
+namelist <- names(league)
+#save output to csvs
+for ( i in seq_along(league) ) {
+  filename <- paste0("updates/",names(league)[i], ".csv")
+  write.csv(league[[i]], file = filename, row.names = FALSE)
+}
 

--- a/updates/Drake.csv
+++ b/updates/Drake.csv
@@ -1,0 +1,6 @@
+"artist","artist_code","baseline","06/01/23"
+"VRSS","1o963gG7zP39nwOenqzPg2",1690,1591
+"Arcy Drive","7o1TBmx7Ube5h2Czlam84O",141332,146278
+"DNL","7aXH52JKx39Q5PprJmFxXu",10323,6464
+"Keiran Ivy","0wzHzFNLOLex8psv09KqNK",23428,28868
+"KHI INFINITE","6wthNkb9tOcsMdNtrHI5vs",426971,559950

--- a/updates/Feldman.csv
+++ b/updates/Feldman.csv
@@ -1,0 +1,6 @@
+"artist","artist_code","baseline","06/01/23"
+"Cinya Khan","7nv9u1rH0xrKytpgKfDKfz",2745,3163
+"Flaujae","5IQcgEvxwvq8kwy4iWCiBC",124864,117814
+"Daoud","3e76yvk1gLZQhKZiUHkMsP",33168,12593
+"YPC Nige","13crAKmlVhj6yzOO9fuOmF",30521,32791
+"jamesjamesjames","0DqR5aQYPz1s2M3YbycLMJ",630692,630665

--- a/updates/GUT.csv
+++ b/updates/GUT.csv
@@ -1,0 +1,6 @@
+"artist","artist_code","baseline","06/01/23"
+"BXB LOVE","03k90jclqTrew2X2DFnRCC",1051,1009
+"Mike Sabbath","3UTCjjwxYJioyA39EX6ciu",177982,173312
+"Louis Millne","6oVWsUniV39LusFsC7axlb",129320,128380
+"Ogi","60nDKjd690Luygtd3Fm0Cu",227880,228727
+"Mochakk","0rTh1tAdrEbdKZBTiiAQSo",826429,866347

--- a/updates/Graham.csv
+++ b/updates/Graham.csv
@@ -1,0 +1,6 @@
+"artist","artist_code","baseline","06/01/23"
+"BBiche","1m0M7J2El2DioTfule3L41",8774,8269
+"Theo Kandel","0YEY41EVT9qE1IdDDDyF9q",68423,67852
+"Anna Bates","4JLqUtfyFvInfcLILCOIJx",172806,174139
+"Peark & The Oysters","7ovvjgqrTeuMxbzIykUqDs",164653,166698
+"Zinadelphia","2bTnGGWvuVQsMVyg31rmum",522497,479170

--- a/updates/Hoch.csv
+++ b/updates/Hoch.csv
@@ -1,0 +1,6 @@
+"artist","artist_code","baseline","06/01/23"
+"semiratuth","6vjKiruwh9k8dDi1rYvI82",1248,1228
+"Emanuel Satie","3veg7sFGWTk62Ecwj6mzij",97818,97787
+"MELT","0G7KI9I5BApiXc5Sqpyil9",140738,142741
+"Murphys Law","1q85MRE0aEF6NfZQdlMrl1",92716,110645
+"Ray Vaughan","4yYYCSCDUTypErQMZv5iSg",335847,323310

--- a/updates/Lamstein.csv
+++ b/updates/Lamstein.csv
@@ -1,0 +1,6 @@
+"artist","artist_code","baseline","06/01/23"
+"Mel 4ever","7e34iWed5vSXh7wAoejlOJ",4925,5918
+"FKA MASH","6tooLez7Cq2bgY60m3TJMq",166838,165892
+"Remmy Quinn","6OQoRzjz71ofDCQa5OTlfq",33814,31992
+"Ben Sterling","79uJoLQkQ621xZy7MyH4uL",55276,61031
+"Justin Jay","5k5eiijuHxrGwXp2Pz37GZ",309695,331706

--- a/updates/Liam.csv
+++ b/updates/Liam.csv
@@ -1,0 +1,6 @@
+"artist","artist_code","baseline","06/01/23"
+"Nico Champagne","3aSb1wUqNgbzj9VTgYBhjY",353,338
+"Wa-FU","51miQgR4HHTo5kOwFCeyJo",81884,88009
+"HIGGO","0f1qSxprIDtLaJfIaEJb64",162736,162061
+"Semma Sole","6bKkC8yidNL8j94vKjLysJ",12793,12675
+"PCRC","41Nu7NgAj9rJxjj7JDuXrV",360087,363200

--- a/updates/Trues.csv
+++ b/updates/Trues.csv
@@ -1,0 +1,6 @@
+"artist","artist_code","baseline","06/01/23"
+"Gibs","6UEqUjzkCgVcEgJ5avKeFv",4774,5675
+"DJ Chus","7kxOVclB0zQamtBR0syCrg",248524,244349
+"Crackazat","2PagBkTVHoKFjuxtCJp3As",211869,212675
+"Tiny Habits","2QYdqWGgRorVkA8cJMMdrn",195807,187473
+"Mall Grab","7yF6JnFPDzgml2Ytkyl5D7",780378,817521


### PR DESCRIPTION
Instead of output of get_data being  a named list of dataframes it's instead csvs that can then be pasted in google sheets (will figure out how to automate this). What this is missing is updating the base structure to include the new data, but if we can just paste the new column into google sheets then that's not totally necessary. 